### PR TITLE
Bump python version and add CI tests

### DIFF
--- a/.github/workflows/deb-ci.yml
+++ b/.github/workflows/deb-ci.yml
@@ -31,7 +31,7 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           pip install --disable-pip-version-check --no-cache-dir tomli tomli-w
-          python -m unittest -v
+          python -m unittest discover -s tests -p "test_*.py" -v
 
       - name: Stamp CI version
         run: |
@@ -53,7 +53,8 @@ jobs:
           text = re.sub(r"^(mpwrd-config \\()[^)]+(\\))", r"\\1" + ci + r"\\2", text, count=1, flags=re.M)
           changelog.write_text(text, encoding="utf-8")
           upstream = base.rsplit("-", 1)[0] if "-" in base else base
-          pep = f"{upstream}+git{date}.{sha}"
+          pep_upstream = upstream.replace(":", "!", 1)
+          pep = f"{pep_upstream}+git{date}.{sha}"
           setup_cfg = Path("setup.cfg")
           setup_text = setup_cfg.read_text(encoding="utf-8")
           setup_text = re.sub(r"^version\\s*=\\s*.+$", f"version = {pep}", setup_text, flags=re.M)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mpwrd-config (1:0.0.1-1) unstable; urgency=medium
+
+  * Add epoch to preserve upgrade path after version reset.
+
+ -- Ruledo <ruledo707@gmail.com>  Sun, 15 Feb 2026 11:20:22 +0000
+
 mpwrd-config (0.0-1) unstable; urgency=medium
 
   * Initial public release.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mpwrd-config
-version = 0.0.1
+version = 1!0.0.1
 description = MPWRD configuration tooling (Python-first, KISS)
 
 [options]


### PR DESCRIPTION
- Set Python package version to 0.0.1 in setup.cfg\n- Run unit tests in CI before stamping versions